### PR TITLE
Changes from background agent bc-64809c0a-ee82-4dfd-9871-7521062a16d2

### DIFF
--- a/add_comment.php
+++ b/add_comment.php
@@ -1,0 +1,95 @@
+<?php
+// add_comment.php - Save a new comment for a tattoo
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: Content-Type');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+function send_json($data, int $status = 200): void {
+    http_response_code($status);
+    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function ensure_data_dir(string $dir): void {
+    if (!is_dir($dir)) {
+        mkdir($dir, 0775, true);
+    }
+}
+
+function comments_file_path(string $tattooId): string {
+    // Avoid unsafe filenames by hashing the identifier
+    $hash = sha1($tattooId);
+    return __DIR__ . '/data/c_' . $hash . '.json';
+}
+
+$raw = file_get_contents('php://input');
+if ($raw === false || $raw === '') {
+    send_json(['success' => false, 'error' => 'Empty request body'], 400);
+}
+
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
+    send_json(['success' => false, 'error' => 'Invalid JSON'], 400);
+}
+
+$tattooId   = isset($payload['tattoo_id']) ? (string)$payload['tattoo_id'] : '';
+$userEmail  = isset($payload['user_email']) ? (string)$payload['user_email'] : '';
+$userName   = isset($payload['user_name']) ? (string)$payload['user_name'] : '';
+$commentTxt = isset($payload['comment_text']) ? (string)$payload['comment_text'] : '';
+
+if ($tattooId === '' || $userEmail === '' || $userName === '' || $commentTxt === '') {
+    send_json(['success' => false, 'error' => 'Missing required fields'], 400);
+}
+
+// Basic validation
+if (!filter_var($userEmail, FILTER_VALIDATE_EMAIL)) {
+    send_json(['success' => false, 'error' => 'Invalid email'], 400);
+}
+
+// Normalize strings
+$userName = trim($userName);
+$commentTxt = trim($commentTxt);
+
+$dir = __DIR__ . '/data';
+ensure_data_dir($dir);
+$file = comments_file_path($tattooId);
+
+$comment = [
+    'id' => bin2hex(random_bytes(8)),
+    'user_name' => $userName,
+    'user_email' => $userEmail,
+    'comment_text' => $commentTxt,
+    'comment_date' => (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(DateTime::ATOM),
+];
+
+$comments = [];
+if (file_exists($file)) {
+    $existing = file_get_contents($file);
+    if ($existing !== false && $existing !== '') {
+        $decoded = json_decode($existing, true);
+        if (is_array($decoded)) {
+            $comments = $decoded;
+        }
+    }
+}
+
+$comments[] = $comment;
+
+// Persist with simple lock to reduce race risk
+$tmp = json_encode($comments, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+if ($tmp === false) {
+    send_json(['success' => false, 'error' => 'Failed to encode comments'], 500);
+}
+
+if (file_put_contents($file, $tmp, LOCK_EX) === false) {
+    send_json(['success' => false, 'error' => 'Failed to save comment'], 500);
+}
+
+send_json(['success' => true, 'comment' => $comment]);

--- a/delete_comment.php
+++ b/delete_comment.php
@@ -1,0 +1,84 @@
+<?php
+// delete_comment.php - Delete a comment by id for a tattoo if requester matches email
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: Content-Type');
+header('Access-Control-Allow-Methods: POST, OPTIONS');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+function send_json($data, int $status = 200): void {
+    http_response_code($status);
+    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function comments_file_path(string $tattooId): string {
+    $hash = sha1($tattooId);
+    return __DIR__ . '/data/c_' . $hash . '.json';
+}
+
+$raw = file_get_contents('php://input');
+if ($raw === false || $raw === '') {
+    send_json(['success' => false, 'error' => 'Empty request body'], 400);
+}
+
+$payload = json_decode($raw, true);
+if (!is_array($payload)) {
+    send_json(['success' => false, 'error' => 'Invalid JSON'], 400);
+}
+
+$tattooId  = isset($payload['tattoo_id']) ? (string)$payload['tattoo_id'] : '';
+$commentId = isset($payload['comment_id']) ? (string)$payload['comment_id'] : '';
+$requester = isset($payload['user_email']) ? (string)$payload['user_email'] : '';
+
+if ($tattooId === '' || $commentId === '' || $requester === '') {
+    send_json(['success' => false, 'error' => 'Missing required fields'], 400);
+}
+
+if (!filter_var($requester, FILTER_VALIDATE_EMAIL)) {
+    send_json(['success' => false, 'error' => 'Invalid email'], 400);
+}
+
+$file = comments_file_path($tattooId);
+if (!file_exists($file)) {
+    send_json(['success' => false, 'error' => 'Not found'], 404);
+}
+
+$rawComments = file_get_contents($file);
+$comments = json_decode($rawComments, true);
+if (!is_array($comments)) {
+    send_json(['success' => false, 'error' => 'Corrupted data'], 500);
+}
+
+$found = false;
+$updated = [];
+foreach ($comments as $c) {
+    if (($c['id'] ?? '') === $commentId) {
+        if (strcasecmp($c['user_email'] ?? '', $requester) !== 0) {
+            send_json(['success' => false, 'error' => 'Forbidden'], 403);
+        }
+        $found = true;
+        continue; // skip to delete
+    }
+    $updated[] = $c;
+}
+
+if (!$found) {
+    send_json(['success' => false, 'error' => 'Comment not found'], 404);
+}
+
+$tmp = json_encode($updated, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+if ($tmp === false) {
+    send_json(['success' => false, 'error' => 'Failed to encode comments'], 500);
+}
+
+if (file_put_contents($file, $tmp, LOCK_EX) === false) {
+    send_json(['success' => false, 'error' => 'Failed to persist changes'], 500);
+}
+
+send_json(['success' => true]);

--- a/get_comments.php
+++ b/get_comments.php
@@ -1,0 +1,50 @@
+<?php
+// get_comments.php - Retrieve comments for a tattoo
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: Content-Type');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+function send_json($data, int $status = 200): void {
+    http_response_code($status);
+    echo json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    exit;
+}
+
+function comments_file_path(string $tattooId): string {
+    $hash = sha1($tattooId);
+    return __DIR__ . '/data/c_' . $hash . '.json';
+}
+
+$tattooId = isset($_GET['tattoo_id']) ? (string)$_GET['tattoo_id'] : '';
+if ($tattooId === '') {
+    send_json([]); // empty list if missing
+}
+
+$file = comments_file_path($tattooId);
+if (!file_exists($file)) {
+    send_json([]);
+}
+
+$raw = file_get_contents($file);
+if ($raw === false || $raw === '') {
+    send_json([]);
+}
+
+$decoded = json_decode($raw, true);
+if (!is_array($decoded)) {
+    send_json([]);
+}
+
+// Sort by date ascending
+usort($decoded, function($a, $b) {
+    return strcmp($a['comment_date'] ?? '', $b['comment_date'] ?? '');
+});
+
+send_json($decoded);


### PR DESCRIPTION
Implement PHP endpoints for tattoo comment management (add, retrieve, delete) to enable persistent storage.

Previously, tattoo comment functionality was simulated client-side. These new PHP scripts provide a server-side solution, storing comments in JSON files under a `data/` directory, ensuring comments persist across sessions and users.

---
<a href="https://cursor.com/background-agent?bcId=bc-64809c0a-ee82-4dfd-9871-7521062a16d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64809c0a-ee82-4dfd-9871-7521062a16d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

